### PR TITLE
Add ability to view routes without link

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -8,6 +8,14 @@ app.use(express.static(path.join(__dirname, '/dist')));
 
 app.use(express.json());
 
+app.get('/*', (req, res) => {
+  res.sendFile(path.join(__dirname, '/dist/index.html'), (err) => {
+    if (err) {
+      res.status(500).send(err);
+    }
+  });
+});
+
 app.listen(port, () => {
   console.log(`Listening at http://localhost:${port}`);
 });


### PR DESCRIPTION
I ran into an issue with React Router. Because routing was done on the client-side, it disabled the ability to refresh or navigate to the URL by pasting it into the web browser.

I believe we previously had this code, but maybe it got lost in the shuffle.

[Stack Overflow](https://stackoverflow.com/questions/27928372/react-router-urls-dont-work-when-refreshing-or-writing-manually)